### PR TITLE
Fix for Redundant assignment

### DIFF
--- a/scripts/legacy/extract_embedded_filenames.py
+++ b/scripts/legacy/extract_embedded_filenames.py
@@ -42,8 +42,6 @@ for path, content in files.items():
         rel_dir = path
         if rel_dir.startswith('examples/'):
             rel_dir = rel_dir[len('examples/'):]
-        else:
-            rel_dir = rel_dir
         # create target path
         # put extracted file in same subdirectory as the FILE; use sanitize minimal
         out_dir = TARGET_BASE / rel_dir


### PR DESCRIPTION
In general, the way to fix self-assignment is either to remove the redundant assignment or to replace it with the correct intended logic. Here, `rel_dir` is initialized as `path`, and if it starts with `"examples/"` the prefix is stripped; otherwise, the code does nothing meaningful. Keeping an `else` with `rel_dir = rel_dir` adds no functionality and is unnecessary.

The safest fix that does not change current behavior is to remove the `else:` block and its self-assignment, allowing the code to simply leave `rel_dir` unchanged when it does not start with `"examples/"`. This preserves exactly the same runtime effect while eliminating the CodeQL warning. Concretely, in `scripts/legacy/extract_embedded_filenames.py`, lines 42–46 should be adjusted so that the `else:` branch is removed, leaving just the `if rel_dir.startswith('examples/'):` block and then continuing with directory creation. No new imports or helper functions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._