### PR TITLE
Fix Faeder/FceRI network generation

### DIFF
--- a/packages/engine/src/parser/BNGLParserWrapper.ts
+++ b/packages/engine/src/parser/BNGLParserWrapper.ts
@@ -27,11 +27,11 @@ export interface ParseResult {
   errors: ParseError[];
 }
 
-const MOLECULES_CHECK_RE = /molecules/i;
-const BEGIN_MOLECULES_RE = /^[^\S\r\n]*(?!#)begin\s+molecules\b/im;
-const END_MOLECULES_RE = /^[^\S\r\n]*(?!#)end\s+molecules\b/im;
-const BEGIN_MOLECULES_REPLACE_RE = /(^[^\S\r\n]*(?!#)begin\s+)molecules\b/gim;
-const END_MOLECULES_REPLACE_RE = /(^[^\S\r\n]*(?!#)end\s+)molecules\b/gim;
+const MOLECULES_CHECK_RE = /(?:molecules|molecular\s+types)/i;
+const BEGIN_MOLECULES_RE = /^[^\S\r\n]*(?!#)begin\s+(?:molecules|molecular\s+types)\b/im;
+const END_MOLECULES_RE = /^[^\S\r\n]*(?!#)end\s+(?:molecules|molecular\s+types)\b/im;
+const BEGIN_MOLECULES_REPLACE_RE = /(^[^\S\r\n]*(?!#)begin\s+)(?:molecules|molecular\s+types)\b/gim;
+const END_MOLECULES_REPLACE_RE = /(^[^\S\r\n]*(?!#)end\s+)(?:molecules|molecular\s+types)\b/gim;
 
 const LOCAL_CONTEXT_MATCH_RE = /%([A-Za-z_][A-Za-z0-9_]*)::/g;
 const LOCAL_CONTEXT_STRIP_RE = /%[A-Za-z_][A-Za-z0-9_]*::/g;
@@ -164,7 +164,8 @@ export function parseBNGLWithANTLR(input: string): ParseResult {
       sanitizedInput = input.substring(1);
     }
 
-    // Normalize legacy 'begin molecules' / 'end molecules' blocks to
+    // Normalize legacy molecule block aliases ('molecules' and
+    // 'molecular types') to
     // the preferred 'begin molecule types' / 'end molecule types' form.
     // We do this as a pre-parse normalization to preserve repository files
     // but remain compatible with BNG2.pl. We skip lines that are comments.
@@ -522,7 +523,7 @@ export function parseBNGLWithANTLR(input: string): ParseResult {
     const { normalized: legacyBlockNormalized, warned } = normalizeLegacyBlocks(sanitizedInput);
     sanitizedInput = legacyBlockNormalized;
     if (warned) {
-      console.warn('[BNGL parser] Rewrote legacy "begin molecules"/"end molecules" to "begin molecule types" for parsing. Consider updating the model file.');
+      console.warn('[BNGL parser] Rewrote legacy molecule block alias ("molecules"/"molecular types") to "molecule types" for parsing. Consider updating the model file.');
     }
 
     const { normalized: legacySyntaxNormalized, warnings: legacyWarnings } = normalizeLegacySyntax(sanitizedInput);

--- a/packages/engine/src/services/graph/NetworkGenerator.ts
+++ b/packages/engine/src/services/graph/NetworkGenerator.ts
@@ -4739,25 +4739,6 @@ export class NetworkGenerator {
           }
 
           if (!bondPreserved) {
-            // For repeated same-name components, occurrence-based matching can be ambiguous.
-            // Re-check all same-name product components before concluding this bond is broken.
-            for (const ppComp of pMol.components) {
-              if (ppComp.name !== rpComp.name) continue;
-              if (ppComp.wildcard === '+' || ppComp.wildcard === '?') {
-                bondPreserved = true;
-                break;
-              }
-              for (const [ppBondLabel] of ppComp.edges) {
-                if (ppBondLabel === bondLabel) {
-                  bondPreserved = true;
-                  break;
-                }
-              }
-              if (bondPreserved) break;
-            }
-          }
-
-          if (!bondPreserved) {
             // This bond is broken - mark only the specific bond pair(s) for this label.
             const componentKey = `${reactantPatternMolIdx}.${rpCompIdx}`;
             const targetCompKey = match.componentMap.get(componentKey);

--- a/packages/engine/src/services/graph/core/Canonical.ts
+++ b/packages/engine/src/services/graph/core/Canonical.ts
@@ -397,6 +397,20 @@ export class GraphCanonicalizer {
       return (canonicalRank.get(a) || 0) - (canonicalRank.get(b) || 0);
     });
 
+    // WL/Nauty refinement identifies equivalent molecule classes, but neither
+    // result is sufficient on its own to choose a stable orientation for a
+    // graph with several interchangeable branches.  In that case two
+    // isomorphic species can otherwise receive different bond labels and enter
+    // the network as separate species.  Resolve the small ambiguous cases by
+    // minimizing the complete serialized graph over the refined permutations.
+    // Large highly symmetric graphs retain the existing bounded fallback so
+    // canonicalization remains safe for arbitrary polymers.
+    const symmetryCanonical = this.tryCanonicalizeByPermutation(graph, moleculeInfos, finalOrder);
+    if (symmetryCanonical !== undefined) {
+      graph.cachedCanonical = symmetryCanonical;
+      return symmetryCanonical;
+    }
+
 
 
     // 4. Construct Mapping Maps
@@ -506,6 +520,208 @@ export class GraphCanonicalizer {
     const finalResult = graph.compartment ? `@${graph.compartment}::${canonicalMolecules}` : canonicalMolecules;
     graph.cachedCanonical = finalResult;
     return finalResult;
+  }
+
+  private static tryCanonicalizeByPermutation(
+    graph: SpeciesGraph,
+    moleculeInfos: MoleculeInfo[],
+    baseOrder: number[],
+  ): string | undefined {
+    const MAX_PERMUTATIONS = 100_000;
+    const factorial = (n: number): number => {
+      let value = 1;
+      for (let i = 2; i <= n; i++) {
+        value *= i;
+        if (value > MAX_PERMUTATIONS) return MAX_PERMUTATIONS + 1;
+      }
+      return value;
+    };
+
+    const moleculeGroups = new Map<string, number[]>();
+    for (const info of moleculeInfos) {
+      // Refined color IDs depend on the order in which component names are
+      // discovered, so they are not a safe part of an isomorphism key.  Local
+      // molecule signatures are invariant; any additional structural
+      // distinction is resolved by the permutation minimization itself.
+      const key = info.localSignature;
+      const members = moleculeGroups.get(key) ?? [];
+      members.push(info.originalIndex);
+      moleculeGroups.set(key, members);
+    }
+
+    const moleculePermutationCount = [...moleculeGroups.values()]
+      .reduce((count, members) => count * factorial(members.length), 1);
+
+    const componentOptions = new Map<number, number[][]>();
+    let componentPermutationCount = 1;
+    for (let molIdx = 0; molIdx < graph.molecules.length; molIdx++) {
+      const molecule = graph.molecules[molIdx];
+      const groups = new Map<string, number[]>();
+      for (let compIdx = 0; compIdx < molecule.components.length; compIdx++) {
+        const component = molecule.components[compIdx];
+        const base = `${component.name}~${component.state ?? ''}\u0000${component.wildcard ?? ''}`;
+        const members = groups.get(base) ?? [];
+        members.push(compIdx);
+        groups.set(base, members);
+      }
+      const options: number[][] = [[]];
+      for (const key of [...groups.keys()].sort()) {
+        const members = groups.get(key)!;
+        const permutations = this.permutations(members);
+        const next: number[][] = [];
+        for (const prefix of options) {
+          for (const permutation of permutations) {
+            next.push([...prefix, ...permutation]);
+          }
+        }
+        options.splice(0, options.length, ...next);
+        componentPermutationCount *= factorial(members.length);
+      }
+      componentOptions.set(molIdx, options);
+    }
+
+    const totalPermutations = moleculePermutationCount * componentPermutationCount;
+    if (totalPermutations <= 1 || totalPermutations > MAX_PERMUTATIONS) {
+      return undefined;
+    }
+
+    const orderByGroup = new Map<string, number[]>();
+    const positionsByGroup = new Map<string, number[]>();
+    for (const [key, members] of moleculeGroups) {
+      const orderedMembers = members.slice().sort((a, b) => baseOrder.indexOf(a) - baseOrder.indexOf(b));
+      orderByGroup.set(key, orderedMembers);
+      positionsByGroup.set(key, orderedMembers.map(molIdx => baseOrder.indexOf(molIdx)).sort((a, b) => a - b));
+    }
+    const orderedGroups = [...moleculeGroups.keys()]
+      .sort((a, b) => {
+        const aPos = Math.min(...(orderByGroup.get(a) ?? []).map(m => baseOrder.indexOf(m)));
+        const bPos = Math.min(...(orderByGroup.get(b) ?? []).map(m => baseOrder.indexOf(m)));
+        return aPos - bPos;
+      });
+
+    let best: string | undefined;
+    const moleculeOrder = new Array<number>(baseOrder.length);
+    const componentOrder = new Map<number, number[]>();
+
+    const visitComponents = (index: number): void => {
+      if (index === baseOrder.length) {
+        const candidate = this.serializeCanonicalOrder(graph, moleculeOrder, componentOrder);
+        if (best === undefined || candidate < best) best = candidate;
+        return;
+      }
+      const molIdx = moleculeOrder[index];
+      const options = componentOptions.get(molIdx) ?? [[...graph.molecules[molIdx].components.keys()]];
+      for (const option of options) {
+        componentOrder.set(molIdx, option);
+        visitComponents(index + 1);
+      }
+    };
+
+    const visitMolecules = (groupIndex: number): void => {
+      if (groupIndex === orderedGroups.length) {
+        visitComponents(0);
+        return;
+      }
+      const key = orderedGroups[groupIndex];
+      const members = orderByGroup.get(key) ?? [];
+      const positions = positionsByGroup.get(key) ?? [];
+      for (const permutation of this.permutations(members)) {
+        permutation.forEach((molIdx, offset) => {
+          moleculeOrder[positions[offset]] = molIdx;
+        });
+        visitMolecules(groupIndex + 1);
+      }
+    };
+
+    visitMolecules(0);
+    return best;
+  }
+
+  private static permutations(values: number[]): number[][] {
+    if (values.length <= 1) return [values.slice()];
+    const result: number[][] = [];
+    for (let i = 0; i < values.length; i++) {
+      const rest = values.slice(0, i).concat(values.slice(i + 1));
+      for (const suffix of this.permutations(rest)) {
+        result.push([values[i], ...suffix]);
+      }
+    }
+    return result;
+  }
+
+  private static serializeCanonicalOrder(
+    graph: SpeciesGraph,
+    moleculeOrder: number[],
+    componentOrder: Map<number, number[]>,
+  ): string {
+    const moleculePosition = new Map<number, number>();
+    moleculeOrder.forEach((molIdx, position) => moleculePosition.set(molIdx, position));
+    const componentPosition = new Map<string, number>();
+    for (const [molIdx, order] of componentOrder) {
+      order.forEach((compIdx, position) => componentPosition.set(`${molIdx}.${compIdx}`, position));
+    }
+
+    const bonds: Array<{
+      leftMol: number;
+      leftComp: number;
+      rightMol: number;
+      rightComp: number;
+    }> = [];
+    for (let i = 0; i < graph.bondList.length; i += 4) {
+      const m1 = graph.bondList[i];
+      const c1 = graph.bondList[i + 1];
+      const m2 = graph.bondList[i + 2];
+      const c2 = graph.bondList[i + 3];
+      const p1 = moleculePosition.get(m1)!;
+      const p2 = moleculePosition.get(m2)!;
+      const q1 = componentPosition.get(`${m1}.${c1}`)!;
+      const q2 = componentPosition.get(`${m2}.${c2}`)!;
+      if (p1 < p2 || (p1 === p2 && q1 <= q2)) {
+        bonds.push({ leftMol: p1, leftComp: q1, rightMol: p2, rightComp: q2 });
+      } else {
+        bonds.push({ leftMol: p2, leftComp: q2, rightMol: p1, rightComp: q1 });
+      }
+    }
+    bonds.sort((a, b) =>
+      a.leftMol - b.leftMol ||
+      a.leftComp - b.leftComp ||
+      a.rightMol - b.rightMol ||
+      a.rightComp - b.rightComp
+    );
+    const bondIds = new Map<string, number>();
+    bonds.forEach((bond, index) => {
+      bondIds.set(`${bond.leftMol}.${bond.leftComp}-${bond.rightMol}.${bond.rightComp}`, index + 1);
+    });
+
+    const molecules = moleculeOrder.map((molIdx, molPosition) => {
+      const molecule = graph.molecules[molIdx];
+      const order = componentOrder.get(molIdx) ?? molecule.components.map((_component, index) => index);
+      const components = order.map(compIdx => {
+        const component = molecule.components[compIdx];
+        let text = component.name;
+        if (component.state && component.state !== '?') text += `~${component.state}`;
+        const labels: number[] = [];
+        for (const bond of bonds) {
+          if (bond.leftMol === molPosition && bond.leftComp === componentPosition.get(`${molIdx}.${compIdx}`)) {
+            labels.push(bondIds.get(`${bond.leftMol}.${bond.leftComp}-${bond.rightMol}.${bond.rightComp}`)!);
+          } else if (bond.rightMol === molPosition && bond.rightComp === componentPosition.get(`${molIdx}.${compIdx}`)) {
+            labels.push(bondIds.get(`${bond.leftMol}.${bond.leftComp}-${bond.rightMol}.${bond.rightComp}`)!);
+          }
+        }
+        if (labels.length > 0) {
+          labels.sort((a, b) => a - b);
+          text += labels.map(id => `!${id}`).join('');
+        } else if (component.wildcard) {
+          text += `!${component.wildcard}`;
+        }
+        return text;
+      });
+      const compartment = molecule.compartment && molecule.compartment !== graph.compartment
+        ? `@${molecule.compartment}`
+        : '';
+      return `${molecule.name}(${components.join(',')})${compartment}`;
+    }).join('.');
+    return graph.compartment ? `@${graph.compartment}::${molecules}` : molecules;
   }
 
   /**

--- a/packages/engine/tests/nauty-canonicalization.spec.ts
+++ b/packages/engine/tests/nauty-canonicalization.spec.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 import { GraphCanonicalizer } from '../src/services/graph/core/Canonical';
 import { Component } from '../src/services/graph/core/Component';
+import { BNGLParser } from '../src/services/graph/core/BNGLParser';
 import { Molecule } from '../src/services/graph/core/Molecule';
 import { NautyService } from '../src/services/graph/core/NautyService';
 import { SpeciesGraph } from '../src/services/graph/core/SpeciesGraph';
@@ -48,6 +49,17 @@ describe('Nauty canonicalization', () => {
     const c2 = GraphCanonicalizer.canonicalize(g2);
 
     expect(c2).toEqual(c1);
+  });
+
+  it('is invariant under swapping repeated receptor branches', () => {
+    const g1 = BNGLParser.parseSpeciesGraph(
+      'Lig(l!1,l!2).Lyn(SH2!3,U).Lyn(SH2!4,U).Rec(a!2,b~pY!3,g~Y).Rec(a!1,b~pY!4,g~Y)'
+    );
+    const g2 = BNGLParser.parseSpeciesGraph(
+      'Lig(l!1,l!2).Lyn(SH2!3,U).Lyn(SH2!4,U).Rec(a!1,b~pY!3,g~Y).Rec(a!2,b~pY!4,g~Y)'
+    );
+
+    expect(GraphCanonicalizer.canonicalize(g2)).toEqual(GraphCanonicalizer.canonicalize(g1));
   });
 
   it('is deterministic across repeated constructions', () => {
@@ -170,4 +182,3 @@ describe('Nauty canonicalization', () => {
     }
   });
 });
-

--- a/packages/engine/tests/network.spec.ts
+++ b/packages/engine/tests/network.spec.ts
@@ -153,6 +153,27 @@ end model
     }
   });
 
+  it('preserves the specific broken bond with repeated wildcard components', async () => {
+    const seed = BNGLParser.parseSpeciesGraph(
+      'Rec(a!2,b~Y,g~Y).Lig(l!1,l!2).Rec(a!1,b~Y,g~Y)'
+    );
+    const rule = BNGLParser.parseRxnRule(
+      'Rec(a!2).Lig(l!2,l!+) -> Rec(a) + Lig(l,l!+)'
+    );
+
+    const result = await new NetworkGenerator({ maxSpecies: 50, maxReactions: 50, maxIterations: 20 }).generate(
+      [seed],
+      [rule]
+    );
+    const products = result.reactions[0].products.map(index =>
+      GraphCanonicalizer.canonicalize(result.species[index].graph)
+    );
+
+    expect(products).toContain('Rec(a,b~Y,g~Y)');
+    const boundProduct = products.find(product => product.startsWith('Lig('));
+    expect(boundProduct).toMatch(/^Lig\([^)]*!1[^)]*\)\.Rec\(a!1,b~Y,g~Y\)$/);
+  });
+
   it('should parse seed species with mathematical expressions', () => {
     const bnglCode = `
 begin model

--- a/packages/engine/tests/parser/BNGLParserWrapper.spec.ts
+++ b/packages/engine/tests/parser/BNGLParserWrapper.spec.ts
@@ -70,6 +70,23 @@ end model
     expect(result.model?.moleculeTypes[0].name).toBe('A');
   });
 
+  it('handles the legacy "begin molecular types" spelling', () => {
+    const legacyBNGL = `
+begin model
+begin molecular types
+  A(s~0~1)
+end molecular types
+begin seed species
+  A(s~0) 10
+end seed species
+end model
+    `;
+
+    const result = parseBNGLWithANTLR(legacyBNGL);
+    expect(result.success).toBe(true);
+    expect(result.model?.moleculeTypes[0].name).toBe('A');
+  });
+
   it('handles line continuations in reaction rules', () => {
     const continuedBNGL = `
 begin model


### PR DESCRIPTION
## Summary

- Make canonical species serialization invariant when repeated molecule branches can be exchanged.
- Preserve the specific reactant bond selected by a rule when repeated component names include wildcard components.
- Normalize both legacy `molecules` and `molecular types` block spellings to `molecule types` without changing model files.

## Root cause

The Faeder/FceRI network contains repeated `Lyn` and `Rec` branches. The previous canonicalization path could assign different bond labels to isomorphic complexes, so they were retained as separate species. The UI then hit its default 5,000-reaction cap and returned a partial network. Separately, the product builder's same-name fallback could treat the wrong repeated wildcard component as preserving a bond, which dropped the ligand from an `R2_rev` product.

## Validation

The exact RuleHub sources were used as temporary fixtures and were not modified:

- `Published/Faeder2003/Faeder_2003.bngl` (`Faeder_2003`)
- `Published/Faeder2003/fceri_ji.bngl` (`fceri_ji`)
- `Published/vilar2002/vilar_2002.bngl` (`vilar_2002`)

The fixed Faeder/FceRI network generates 354 species and 3,680 reactions, matching the native BNG2 output for `fceri_ji`. `vilar_2002` now parses through the generic legacy block normalization. No model files or model-specific branches were added.

Passed:

- `npm run test:fast` — 6,342 passed, 55 skipped
- targeted canonicalization/parser/network tests — 16 passed
- `npm run type-check`

The hang-safe full suite reached 4,591 passing tests, but seven unrelated tests timed out reading the external `/private/tmp/RuleHub` fixture tree in this environment. Repository-wide lint is also pre-existing red (592 errors outside the changed files).
