### PR TITLE
chore: finalize playground parity

### DIFF
--- a/ATOMIZER_SBML_COVERAGE_AUDIT.md
+++ b/ATOMIZER_SBML_COVERAGE_AUDIT.md
@@ -1,0 +1,298 @@
+# Playground Atomizer versus SBML
+
+**Audit date:** 2026-09-08
+**Audited component:** `src/lib/atomizer` in `julesplayground`
+**Baseline repository commit:** `d9226a164df335ab5ece8c3b091c0c1a235e1b98`
+**Assessment status:** baseline audit plus post-fix validation on branch `codex/atomizer-sbml-parity`.
+
+## Executive conclusion
+
+The Atomizer is a useful importer for a substantial **kinetic, flat SBML subset**: compartments, species, parameters, reactions, common kinetic-law MathML, many rules, initial assignments, unit scaling, annotations, and a small class of fixed-time events. This explains its strong performance on curated BioModels-style models.
+
+It is not a general SBML importer. The correct product claim is:
+
+> **SBML Level 3 Version 2 Core kinetic-subset importer to BNGL, with explicit loss/approximation diagnostics.**
+
+It should not currently claim complete SBML coverage or semantic round-trip fidelity. The baseline audit found these highest-risk findings; the first two have now been fixed or made fail-closed on this branch:
+
+1. **Baseline: twelve of 1,692 official L3V2 semantic cases generated invalid BNGL.** Empty MathML operands and rules with missing MathML were the cause. The branch fixes these cases: the post-fix suite has 0 strict-output failures.
+2. **Events are mostly diagnostic-only:** the baseline translated 3 of 200 event-bearing suite models, including an unsafe mutable-parameter fold. The branch now translates only compile-time-constant event expressions; post-fix results are 2 converted and 198 explicitly untranslated.
+3. **Algebraic rules are dropped**, not solved as implicit DAE constraints: 102 suite files carried them.
+4. **Variable or non-integer stoichiometry is approximated as fixed integer stoichiometry:** 98 suite files carried a stoichiometry warning, with 809 warning records.
+5. **Model-changing Level 3 packages are not imported:** `comp`, `multi`, `fbc`, `qual`, `spatial`, `arrays`, `distrib`, and `dyn`. Some are intentionally outside the requested kinetic scope, but the resulting output must be treated as incomplete.
+6. **`multi` has a useful structural prototype, but its reconstructed molecule types and complexes are emitted only as comments and are not connected to the simulated network.**
+
+The importer usually returns `success: true` while reporting dropped or approximated content. Consumers must inspect `importWarnings`; success means “the import pipeline returned,” not “the SBML model was preserved.”
+
+### Post-fix validation on this branch
+
+The same pinned 1,692-file semantic harness was rerun after the changes in this branch:
+
+| Gate | Baseline | Post-fix |
+| --- | ---: | ---: |
+| Atomizer returned success | 1,692 / 1,692 | 1,692 / 1,692 |
+| Generated BNGL passed strict parser | 1,680 / 1,692 | **1,692 / 1,692** |
+| Strict-output failures | 12 | **0** |
+| Event models converted | 3 | 2 (safe constant-only subset) |
+| Event models explicitly untranslated | 197 | 198 |
+
+The post-fix run also recorded 13 `missingMath` diagnostics rather than emitting blank executable functions. Explicit `useValuesFromTriggerTime="false"` is now preserved, and mutable event assignments are left annotated rather than folded to initial parameter values.
+
+An executable round-trip was validated in the separate conda environment `atomizer-sbml-roundtrip` using Python 3.11, libSBML 5.21.1, and libRoadRunner 2.10.0. Atomizer BNGL was processed by BNG2 2.9.3 to SBML; libSBML reported zero errors, libRoadRunner simulated 11 rows through `t=1` with finite values, and Atomizer re-imported the resulting SBML with strict BNGL parsing succeeding. This is a representative interoperability gate, not proof of all-model trajectory equivalence.
+
+## Standards baseline
+
+At audit time, the SBML project identifies [SBML Level 3 Version 2 Core Release 2](https://sbml.org/documents/specifications/level-3/version-2/) as the current stable Core specification. The [SBML specification index](https://sbml.org/documents/specifications/level-3/) lists released Level 3 packages including `comp`, `distrib`, `fbc`, `groups`, `layout`, `multi`, `qual`, `render`, and `spatial`; `arrays` and `dyn` are listed as draft packages, while the mathematical-extensions package is not started. This audit therefore distinguishes:
+
+- **Core L3V2 coverage:** tested against the official SBML Test Suite semantic cases.
+- **Package behavior:** tested against official libSBML examples where available plus small namespace fixtures for package detection.
+- **Unsupported model classes:** `qual` and `fbc` are recorded as explicit non-goals, per request. Their package detection and failure behavior are still assessed.
+
+The official [SBML Test Suite documentation](https://sbml.org/software/sbml-test-suite/docs/test-case-details/) separates syntactic, semantic, and stochastic cases. This audit used the semantic L3V2 files because they exercise model interpretation rather than XML acceptance alone.
+
+## What was fetched and tested
+
+To avoid changing the user's dirty working tree, the audit fetched a fresh isolated shallow clone of the user's repository from:
+
+`https://github.com/akutuva21/julesplayground.git`
+
+The isolated clone resolved to the audited commit above. The authoritative checkout's pre-existing edits were not staged, committed, reset, or overwritten.
+
+Additional read-only source snapshots:
+
+| Source | Snapshot | Use |
+| --- | --- | --- |
+| `julesplayground` | `d9226a1` | Atomizer implementation and local tests |
+| [SBML Test Suite](https://github.com/sbmlteam/sbml-test-suite) | `473e119dd57226c3a7a729d598f9007f06f781c3`, `VERSION.txt = 3.3.0` | 1,692 `*-sbml-l3v2.xml` semantic cases |
+| [libSBML](https://github.com/sbmlteam/libsbml) | `6d26cef5f2557f13f59c9e2d6ef063a3de300d75` | Official package sample models |
+
+The suite harness ran every one of the 1,692 L3V2 semantic XML files through Atomizer, then passed generated BNGL through the playground's strict BNGL parser. It also recorded warnings, model counts, package namespaces, and event conversion status. Package samples were checked in the same way.
+
+This is a structural and translation audit. It is not a claim that every accepted output reproduces the SBML trajectory. Full trajectory equivalence needs a model-by-model oracle and careful handling of solver tolerances, events, units, and rule semantics.
+
+## Measured results
+
+### Official L3V2 semantic suite
+
+| Gate | Result | Interpretation |
+| --- | ---: | --- |
+| XML files exercised | 1,692 | All available L3V2 semantic cases in the fetched suite snapshot |
+| Atomizer returned success | 1,692 / 1,692 | Pipeline did not throw on these cases |
+| Generated BNGL passed strict parser | 1,680 / 1,692 (99.29%) | Useful syntax gate, not semantic equivalence |
+| Generated BNGL failed strict parser | 12 / 1,692 (0.71%) | Concrete correctness failures; listed below |
+| Files with event diagnostics | 200 | Event behavior is common enough to require first-class support |
+| Events converted to scheduled actions | 3 / 200 models | Only simple fixed-time, constant-foldable cases |
+| Events left untranslated | 197 / 200 models | Emitted as diagnostics/comments rather than executable dynamics |
+| Files with algebraic-rule diagnostics | 102 | Algebraic rules are not represented as DAE constraints |
+| Files with stoichiometry diagnostics | 98 | Variable/non-integer stoichiometry is approximated |
+| Stoichiometry warning records | 809 | 773 variable/StoichiometryMath and 36 non-integer records |
+| Files with constraints | 1 | Constraint is counted/diagnosed, not enforced |
+| Files with `comp` namespace | 125 | Detected and dropped in this bundled build |
+| Files with `fbc` namespace | 34 | Detected and dropped; outside kinetic scope |
+
+Warning records in the suite were:
+
+| Warning category | Records | Severity |
+| --- | ---: | --- |
+| `algebraicRule` | 102 | dropped |
+| `constraint` | 1 | info |
+| `event` | 200 | dropped |
+| `mathml` | 376 | info/approximated |
+| `package:comp` | 125 | dropped |
+| `package:fbc` | 34 | dropped |
+| `stoichiometry` | 809 | approximated |
+
+### The 12 baseline strict-output failures (now fixed)
+
+| Case | Exercised feature | Failure |
+| --- | --- | --- |
+| 01112 | Zero-child `plus`, `times`, `and`, `or`, `xor` MathML | Empty operands emitted as `()` or malformed logical expressions |
+| 01114 | Nested zero-child MathML | Same empty-operand problem through nested expressions |
+| 01464 | Rate rule with no MathML on a species reference | Blank rate-rule function emitted |
+| 01465 | Assignment rule with no MathML on a species reference | Blank assignment-rule function emitted |
+| 01489 | Zero-child function-definition MathML | Empty function bodies emitted |
+| 01491 | Nested zero-child function-definition MathML | Empty/malformed function expressions emitted |
+| 01552 | Assignment rule with no MathML on stoichiometry | Blank assignment-rule function emitted |
+| 01553 | Rate rule with no MathML on stoichiometry | Blank rate-rule function emitted |
+| 01556 | Boundary species with rate rule lacking MathML | Blank rate-rule function emitted |
+| 01561 | Uncommon MathML assigned to stoichiometries | Generated stoichiometry-rule output is not strictly parseable |
+| 01630 | FBC model with a blank generated function | FBC is intentionally dropped, but output also contains an invalid blank function |
+| 01657 | Initial assignment referencing a species with a missing rule MathML | Blank rule function and malformed expression emitted |
+
+These were not merely unsupported-feature warnings: the output itself was invalid BNGL. The branch now routes empty n-ary MathML through the raw MathML reader, applies SBML identities, omits missing rule bodies with diagnostics, and emits a safe zero body for missing function-definition expressions. The pinned post-fix suite produced no strict-output failures.
+
+### Event behavior
+
+The baseline converted suite models were `00980`, `01119`, and `01287`. After the safety fix, only the two constant-only cases remain executable; the mutable assignment-time case `00980` is correctly left untranslated. The supported coverage is narrow:
+
+- trigger must reduce to a simple time threshold;
+- delay must be constant;
+- assignment right-hand sides must fold to constants;
+- targets must be recognized species or parameters;
+- event priority is folded to a constant and used to order same-time writes.
+
+This can be useful for fixed calibration pulses, but it is not general SBML event support. State-triggered events, species-dependent assignments, function-dependent assignments, non-constant delays, repeated firing semantics, and general event scheduling remain untranslated.
+
+The branch fixes the parser defect in [`sbmlParser.ts`](src/lib/atomizer/parser/sbmlParser.ts): explicit `useValuesFromTriggerTime="false"` is preserved. The event translator also refuses to fold mutable parameters, rules, initial-assignment targets, or event-assignment targets. In case `00980`, the generated BNGL now keeps the event in the diagnostic block instead of producing incorrect constant writes such as `p = 3` and `q = 1`.
+
+### Local test gates
+
+Focused Atomizer tests passed:
+
+```text
+Test Files  4 passed (4); Tests 49 passed (49)
+Test Files  6 passed | 1 skipped (7); Tests 36 passed (36)
+```
+
+The repository's hang-safe narrow suite passed on the baseline before these changes:
+
+```text
+npm run test:fast
+Test Files  274 passed | 5 skipped (279)
+Tests       6339 passed | 55 skipped (6394)
+```
+
+The full scientific suite was run with the required safe harness at the final working tree. It completed with 133 files passing, 8 skipped, and 2 failing files (3 tests). The remaining failures were `parity-polymer` and `parity-zap`, both failing before simulation because their RuleHub model lookup returned a null path; none were Atomizer-specific suite failures. Because the run did not produce a clean terminal pass, it is not evidence for a globally green repository.
+
+The post-fix branch-specific gates are the focused Atomizer suite, `tests/atomizer/sbml-core-parity.spec.ts` (5 tests), the full `npm run test:fast` gate, and the pinned 1,692-case semantic harness. The full scientific suite remains a separate repository baseline gate; its final result is recorded above.
+
+## Core SBML coverage matrix
+
+Status meanings:
+
+- **Strong:** extracted and represented for ordinary kinetic models, with the caveats listed.
+- **Partial:** common forms work, but important legal forms are dropped, approximated, or not semantically equivalent.
+- **Diagnostic only:** recognized and reported but not represented in the simulation.
+- **Dropped:** the input structure is not imported.
+
+| SBML Core feature | Status | Observed behavior and limitation |
+| --- | --- | --- |
+| XML/model parsing | Strong for tested L3V2 semantic cases | All 1,692 cases returned from Atomizer; this does not imply preserved meaning. |
+| Compartments | Partial/strong for flat kinetic models | Dimensions, sizes, units, constants, outside relationships, and species compartment membership are extracted. Hierarchical `comp` submodels are not flattened. Dynamic compartment size semantics need separate validation. |
+| Species | Strong for ordinary core models | Initial amount/concentration, units, boundary/constant flags, charge, SBO term, species type, conversion factor, and compartment are captured where exposed by the bundled libSBML build or raw XML fallback. |
+| Parameters | Strong for ordinary core models | Global/local parameters and aliases are extracted. Event translation now folds only parameters and compartments that are declared constant and are not later mutated. |
+| Reactions | Strong for ordinary kinetic models | Reactants, products, modifiers, reversibility, kinetic laws, and local parameters are translated to BNGL. Variable and non-integer stoichiometry is not faithfully representable. |
+| Kinetic-law MathML | Partial/strong for common operators | Arithmetic, powers, roots, logs, min/max, trigonometric/hyperbolic functions, comparisons, logic, piecewise, and common `csymbol` forms are handled. Unsupported or lossy forms can become BNGL expressions, comments, or approximations. |
+| Assignment rules | Partial | Ordinary rules are converted to BNGL observables/functions or initialization structures. Rules with missing MathML are omitted with a `missingMath` diagnostic; stateful semantic equivalence is not guaranteed. |
+| Rate rules | Partial | Ordinary rate rules are represented with auxiliary BNGL species/reactions. Missing MathML is omitted with a `missingMath` diagnostic. This is a translation strategy, not a general DAE solver. |
+| Algebraic rules | Diagnostic only | Counted and reported; not solved as implicit constraints. |
+| Initial assignments | Partial | Common constant expressions are imported. Empty/missing MathML is omitted with a diagnostic. Ordering and dependency semantics need explicit validation. |
+| Function definitions | Partial | Common functions are emitted. Empty bodies now become a diagnostic zero function, and empty n-ary operators follow SBML identities; full SBML function-definition semantics are not established. |
+| Events | Partial, narrow | Only fixed-time, constant-foldable cases are executable; mutable or state-dependent cases remain untranslated. Explicit trigger-time flags are preserved in the parsed model, but general event scheduling semantics are not supported. |
+| Constraints | Diagnostic only | Constraint presence is recorded; constraint math is not enforced during BNGL simulation. |
+| Unit definitions and conversion factors | Partial/strong | Unit definitions and SI-scale factors are extracted and applied in several paths. No complete dimensional-analysis proof or universal unit-equivalence guarantee was established. |
+| Annotations and SBO terms | Metadata only | Read where available; do not change kinetic translation or guarantee semantic interpretation of annotations. |
+| Notes/history/CV terms | Metadata only | Not an executable model feature. Preserve/round-trip behavior was not audited as a document-fidelity requirement. |
+| Avogadro/time `csymbol` | Partial | Common symbols are recognized; unknown symbols fall back with diagnostics. |
+| Piecewise and logical math | Partial | Many forms translate to BNGL `if`; unusual and empty forms expose correctness gaps. |
+| Non-finite values | Approximation risk | Infinity/NaN are normalized or approximated because BNGL cannot represent them generally. These cases require an explicit policy before simulation. |
+
+## Level 3 package matrix
+
+Package status is based on the official [Level 3 package index](https://sbml.org/documents/specifications/level-3/) and the source behavior in [`sbmlParser.ts`](src/lib/atomizer/parser/sbmlParser.ts#L812).
+
+| Package | Status in Atomizer | Evidence and limitation |
+| --- | --- | --- |
+| `comp` | **Dropped; high risk** | The bundled libSBML API cannot perform the required flatten/serialization conversion. Submodels and external model definitions are not expanded. Official comp cases returned, but the output can contain none of the submodel dynamics. |
+| `multi` | **Partial prototype; not simulated** | Canonical shallow `multi` structures can produce BNGL molecule-type and complex-pattern text. Deep Simmune-style hierarchy is detected but not reconstructed. All reconstructed output is commented reference text; it is not fed to the simulated network. |
+| `fbc` | **Explicit non-goal; dropped** | The package is detected and explained as a steady-state flux-balance/linear-program model, not a kinetic ODE/SSA model. No faithful BNGL kinetic translation is attempted. |
+| `qual` | **Explicit non-goal; dropped or rejected** | Qualitative logical transitions are not continuous kinetic rates. A qual-only model with no kinetic reactions is rejected with an explicit unsupported-model error; a mixed model gets a dropped-package warning. |
+| `spatial` | **Dropped; high risk for spatial models** | Geometry, spatial fields, diffusion, and spatial semantics are not imported. Namespace detection works in the audit fixture. |
+| `arrays` | **Dropped** | Array dimensions and indexed expansion are not imported. `arrays2.xml` returned parseable BNGL with zero species/reactions, demonstrating why success alone is insufficient. |
+| `distrib` | **Dropped** | Distribution and uncertainty metadata are not imported; no sampling or uncertainty semantics. |
+| `dyn` | **Dropped** | Dynamic/agent creation and destruction behavior is not imported. |
+| `groups` | **Ignored as non-mathematical metadata** | Group membership is not imported. Safe only when groups are presentation or annotation metadata. |
+| `layout` | **Ignored as non-mathematical metadata** | Diagram coordinates are not imported; mathematical content can remain intact. |
+| `render` | **Ignored as non-mathematical metadata** | Rendering styles are not imported; mathematical content can remain intact. |
+| `req` | **Diagnosed; ignored as metadata** | The retired requirements package is now reported as informational metadata and does not affect the mathematical model. Requirements are not enforced. |
+| `math` extensions | **No explicit support** | The official package index lists the math package as not started. Unknown MathML constructs can be dropped, approximated, or emitted in a form that BNGL cannot parse. |
+
+### Package sample observations
+
+Official libSBML samples and the package fixtures gave these concrete results:
+
+- `arrays1.xml`: Atomizer and strict BNGL parsing succeeded, but array content was dropped and variable stoichiometry was approximated.
+- `arrays2.xml`: Atomizer and strict BNGL parsing succeeded while producing zero species/reactions; this is a successful pipeline result with missing model content.
+- `dyn_example1.xml`: ordinary core content was emitted, while `dyn` content was dropped.
+- `dyn_example2.xml`: `comp` and `dyn` content were dropped; the output contained zero species/reactions.
+- `fbc_example1.xml`: output was parseable, but the FBC objective and flux constraints were dropped by design.
+- `multi/Ecad.xml`: output was parseable, but the model's variable stoichiometry and multi structure were not a faithful simulated complex model.
+- `multi/YeastMAPK.xml`: deep Simmune-style multi hierarchy was detected and explicitly not reconstructed.
+- `multi/multi_example1.xml`: one molecule type and two bonded complex patterns were reconstructed as commented reference text only.
+- comp suite samples `01124`, `01153`, `01344`, and `01361`: output was parseable, but hierarchical composition was not flattened.
+- synthetic namespace fixtures for `layout`, `render`, `groups`, and `req` generated informational warnings; `spatial` and `distrib` generated dropped-package warnings.
+
+## MathML and expression coverage
+
+The converter covers a broad practical subset: identifiers, rational and scientific numbers, Boolean constants, `pi`, `e`, arithmetic, power, root, log, quotient, remainder, factorial, trigonometric/hyperbolic/inverse functions, min/max, relational operators, logical operators, and piecewise expressions.
+
+Important limits:
+
+- Empty `plus`, `times`, `and`, `or`, and `xor` nodes are normalized to SBML identities by the branch's raw MathML fallback. Other unusual empty or unsupported operators still need explicit policy.
+- Missing MathML on legal SBML rule constructs is handled fail-closed by omitting the executable rule and recording a `missingMath` diagnostic; this preserves parseability but not the missing semantics.
+- Factorial is flagged as approximated because BNGL does not provide the same general integer-domain contract.
+- Unknown `csymbol` and unsupported MathML constructs can fall through into identifiers or diagnostic output.
+- Piecewise, comparisons, and logic can be syntactically translated while still having different domain or Boolean coercion behavior in BNGL.
+- There is no complete expression-level dimensional analysis, domain analysis, or proof that every accepted MathML expression has equivalent BNGL evaluation.
+
+## Main limitations by priority
+
+### P0: output correctness — branch status
+
+- **Fixed for the audited Core suite:** blank rule bodies are omitted with diagnostics, empty n-ary MathML identities are normalized, and the pinned post-fix run has 0 strict-output failures.
+- **Still open:** unsupported package-only models can return `success: true` with warnings and parseable but empty/incomplete BNGL. A machine-readable `incomplete` status would make this safer for callers.
+
+### P1: semantic correctness — remaining gaps
+
+- Replace the narrow event constant-folding path with a runtime-preserving representation, or continue rejecting all events outside the proven fixed-time subset.
+- Preserve `useValuesFromTriggerTime`, `initialValue`, `persistent`, priorities, simultaneous assignment semantics, delayed assignments, and repeated firing.
+- Decide whether assignment/rate rules are supported semantically or are only a convenient approximation for a BNGL-compatible subset.
+- Reject or explicitly mark variable and non-integer stoichiometry instead of silently treating it as fixed integer stoichiometry when the result can change dynamics.
+- Add a real constraint policy; currently constraints are metadata only.
+
+### P1: package completeness
+
+- Either expose a full libSBML conversion API for `comp` or fail clearly before emitting incomplete output.
+- Wire canonical `multi` reconstruction into the actual engine only after end-to-end molecule, bond, seed, and rule validation. Until then, keep it diagnostic/reference-only.
+- Keep `qual` and `fbc` out of the kinetic importer, but make their unsupported status machine-readable and test it as a contract.
+- Extend explicit detection to future Level 3 namespaces rather than silently ignoring unknown packages. The retired `req` namespace is now diagnosed as informational.
+
+### P2: breadth and reproducibility
+
+- Add package-specific fixtures for `spatial`, `arrays`, `distrib`, `dyn`, `layout`, `render`, `groups`, and `req`.
+- Add a CI gate over the pinned SBML Test Suite snapshot: Atomizer success, warning classification, strict BNGL parseability, and an allowlist for intentionally unsupported cases.
+- Add trajectory comparisons for a representative Core subset, including units, rate rules, assignment rules, piecewise math, compartments, and fixed-time events.
+- Record source suite version and package versions in every audit artifact.
+
+## Recommended public documentation claim
+
+Use wording close to:
+
+> The Playground Atomizer imports a broad subset of SBML Level 3 Core kinetic models into BNGL. It supports common flat models with compartments, species, parameters, reactions, kinetic laws, rules, initial assignments, unit conversions, and selected fixed-time events. It reports dropped and approximated content. It does not provide general support for hierarchical composition, qualitative models, flux-balance models, spatial models, array/distribution/dynamic packages, or fully general SBML event/algebraic/variable-stoichiometry semantics.
+
+Avoid “SBML supported” without the words **kinetic subset**, **warnings must be reviewed**, and **package limitations**.
+
+## Reproduction commands
+
+The following commands were used in the isolated audit clone. The temporary suite harness and generated evidence stayed outside the user's repository.
+
+```bash
+git clone --depth 1 https://github.com/akutuva21/julesplayground.git /private/tmp/julesplayground-atomizer-audit-20260908
+git clone --depth 1 https://github.com/sbmlteam/sbml-test-suite.git /private/tmp/sbml-test-suite-audit-20260908
+git clone --depth 1 https://github.com/sbmlteam/libsbml.git /private/tmp/libsbml-audit-20260908
+
+npx vitest run --config vitest.config.ts \
+  tests/lib/atomizer/parser/sbmlParser.spec.ts \
+  tests/lib/atomizer/atomization/core.spec.ts \
+  tests/lib/atomizer/writer/bnglWriter.spec.ts \
+  tests/atomizer/regression.spec.ts
+
+npm run test:fast
+npm run test:full:safe
+```
+
+The exhaustive suite pass used the Atomizer API with `quietMode: true`, `useId: true`, and `atomize: false`, followed by `parseBNGLStrict` on the generated BNGL. That mode tests the default flat translation path; it does not claim that `atomize: true` solves the unsupported SBML package semantics.
+
+## Bottom line
+
+The Atomizer is already credible for a common BioModels-like kinetic subset. The audit also found clear, reproducible boundaries outside that subset. The most important engineering result is a safer boundary: unsupported and approximate translations are easier to detect, the 12 invalid-output cases are fixed, and the event semantic defect is fail-closed for mutable expressions. Package-by-package and trajectory-level expansion can now proceed without weakening correctness claims.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5133,8 +5133,6 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  before-after-hook@4.0.0: {}
-
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2

--- a/src/lib/atomizer/parser/sbmlParser.ts
+++ b/src/lib/atomizer/parser/sbmlParser.ts
@@ -834,6 +834,7 @@ export class SBMLParser {
       layout: 'diagram layout',
       render: 'diagram rendering',
       groups: 'element grouping',
+      req: 'requirements metadata (retired package)',
     };
 
     const nsRe = /xmlns:([A-Za-z0-9_]+)\s*=\s*["']http:\/\/www\.sbml\.org\/sbml\/level3\/version\d+\/([a-z]+)\/version\d+["']/gi;
@@ -1944,6 +1945,15 @@ export class SBMLParser {
       case 'math':
       case 'semantics':
       case 'annotation-xml':
+      case 'lambda': {
+        // Function definitions wrap their body in lambda(bvar..., body).  The bound-variable
+        // declarations are metadata for the writer; the last non-bvar child is the expression.
+        if (node.name === 'lambda') {
+          const body = elementChildren.filter((child) => child.name !== 'bvar').pop();
+          return body ? this.mathMlNodeToFormula(body) : '';
+        }
+        return firstChildExpr();
+      }
       case 'condition':
       case 'piece':
       case 'otherwise':
@@ -2099,6 +2109,11 @@ export class SBMLParser {
           case 'or':
           case 'xor':
           case 'not':
+            // SBML defines the n-ary Boolean identities: and() is true, or() and xor() are
+            // false.  Keeping these as empty calls produces invalid BNGL and loses the identity.
+            if (opName === 'and' && a.length === 0) return '1';
+            if ((opName === 'or' || opName === 'xor') && a.length === 0) return '0';
+            if (opName === 'not' && a.length === 0) return '1';
             return `${opName}(${a.join(', ')})`;
           case 'piecewise':
             return `piecewise(${a.join(', ')})`;
@@ -2126,7 +2141,7 @@ export class SBMLParser {
     if (!rxnBlock) return null;
     const kl = rxnBlock[0].match(/<kineticLaw\b[\s\S]*?<\/kineticLaw>/i);
     const scope = kl ? kl[0] : rxnBlock[0];
-    const math = scope.match(/<math\b[\s\S]*?<\/math>/i);
+    const math = scope.match(/<math\b[\s\S]*?<\/math>/i) || scope.match(/<math\b[^>]*\/\s*>/i);
     return math ? math[0] : null;
   }
 
@@ -2143,7 +2158,30 @@ export class SBMLParser {
       block = this.currentSbml.match(new RegExp(`<${tag}\\b[\\s\\S]*?</${tag}>`, 'i'));
     }
     if (!block) return null;
-    const math = block[0].match(/<math\b[\s\S]*?<\/math>/i);
+    const math = block[0].match(/<math\b[\s\S]*?<\/math>/i) || block[0].match(/<math\b[^>]*\/\s*>/i);
+    return math ? math[0] : null;
+  }
+
+  /** Pull a functionDefinition's raw MathML so empty/n-ary operators do not pass through lossy
+   * libSBML formulaToString output. */
+  private rawMathForFunctionDefinition(functionId: string): string | null {
+    if (!this.currentSbml || !functionId) return null;
+    const id = functionId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const block = this.currentSbml.match(
+      new RegExp(`<functionDefinition\\b[^>]*\\bid\\s*=\\s*["']${id}["'][\\s\\S]*?</functionDefinition>`, 'i'));
+    if (!block) return null;
+    const math = block[0].match(/<math\b[\s\S]*?<\/math>/i) || block[0].match(/<math\b[^>]*\/\s*>/i);
+    return math ? math[0] : null;
+  }
+
+  /** Pull an initialAssignment's raw MathML, including self-closing empty math elements. */
+  private rawMathForInitialAssignment(symbol: string): string | null {
+    if (!this.currentSbml || !symbol) return null;
+    const id = symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const block = this.currentSbml.match(
+      new RegExp(`<initialAssignment\\b[^>]*\\bsymbol\\s*=\\s*["']${id}["'][\\s\\S]*?</initialAssignment>`, 'i'));
+    if (!block) return null;
+    const math = block[0].match(/<math\b[\s\S]*?<\/math>/i) || block[0].match(/<math\b[^>]*\/\s*>/i);
     return math ? math[0] : null;
   }
 
@@ -2155,7 +2193,7 @@ export class SBMLParser {
     // literal text (models write it as "Time", "t", " Time ", ...); the writer only rewrites a
     // lowercase `\btime\b` into `time()`, so "Time"/"t" leaked and BNG2 aborted with
     // "Parameter 'Time' referenced but not defined".
-    return /<piecewise\b|<(?:lt|gt|leq|geq|eq|neq|and|or|not|xor)\b|definitionURL\s*=\s*["'][^"']*(?:delay|rateOf|avogadro|time)/i.test(mathXml);
+    return /<piecewise\b|<(?:lt|gt|leq|geq|eq|neq|and|or|not|xor)\b|definitionURL\s*=\s*["'][^"']*(?:delay|rateOf|avogadro|time)|<apply\b[^>]*>\s*<(?:plus|times|minus|divide|power|root|log|quotient|rem|factorial|and|or|xor|not|eq|neq|gt|lt|geq|leq)\b[^>]*\/\s*>\s*<\/apply>/i.test(mathXml);
   }
 
   private safeFormulaToString(math: any): string {
@@ -2479,11 +2517,6 @@ export class SBMLParser {
 
     const rxnAttrs = this.rawElementAttrs('reaction', reactionId);
     const convFactor = this.getXmlAttribute(rxnAttrs, 'conversionFactor') || undefined;
-    if (convFactor) {
-      this.recordWarning('conversionFactor',
-        `Reaction "${reactionId}" declares conversionFactor="${convFactor}"; captured but not yet applied to the rate law.`,
-        'approximated');
-    }
 
     return {
       id: reactionId,
@@ -2543,7 +2576,9 @@ export class SBMLParser {
       }
     }
 
-    // Same lossy-math guard as kinetic laws (see extractReaction).
+    // Prefer the raw MathML whenever the bundled libSBML formula printer is lossy. This includes
+    // empty n-ary operators: formulaToString renders them as `()`/bare names, while the raw reader
+    // can apply SBML's operator identities.
     const rawRuleMath = this.rawMathForRule(ruleType, variable);
     if (this.mathHasLossyConstructs(rawRuleMath)) {
       const fromMathMl = this.mathMlToFormula(rawRuleMath!);
@@ -2556,6 +2591,16 @@ export class SBMLParser {
     }
 
     formula = this.sanitizeMathExpression(this.normalizeFormulaIdentifiers(formula));
+
+    // An empty rule body is not executable BNGL. Dropping it is safer than emitting a blank
+    // function that makes the entire generated model unparsable; the warning keeps the source
+    // defect visible to callers.
+    if (!formula.trim()) {
+      this.recordWarning('missingMath',
+        `${ruleType} rule${variable ? ` for "${variable}"` : ''} has no MathML expression; rule was omitted from the executable BNGL.`,
+        'dropped');
+      return null;
+    }
 
     if (ruleType === 'algebraic') {
       return {
@@ -2632,7 +2677,19 @@ export class SBMLParser {
         }
       }
     }
+    const rawFunctionMath = this.rawMathForFunctionDefinition(func.getId());
+    if (rawFunctionMath) {
+      const fromMathMl = this.mathMlToFormula(rawFunctionMath);
+      if (fromMathMl.trim()) mathStr = fromMathMl;
+    }
     mathStr = this.sanitizeMathExpression(this.normalizeFormulaIdentifiers(mathStr));
+
+    if (!mathStr.trim()) {
+      this.recordWarning('missingMath',
+        `Function definition "${func.getId()}" has no MathML expression; emitted as the constant zero function.`,
+        'approximated');
+      mathStr = '0';
+    }
 
     return {
       id: func.getId(),
@@ -2674,7 +2731,16 @@ export class SBMLParser {
       name: event.getName() || eventId,
       trigger: triggerMath ? this.normalizeFormulaIdentifiers(this.safeFormulaToString(triggerMath)) : '',
       delay: delayMath ? this.normalizeFormulaIdentifiers(this.safeFormulaToString(delayMath)) : undefined,
-      useValuesFromTriggerTime: event.getUseValuesFromTriggerTime?.() || true,
+      // SBML defaults this attribute to true when it is absent. Do not use `|| true`: that turns
+      // an explicit false into true and changes assignment-time event semantics.
+      useValuesFromTriggerTime: (() => {
+        try {
+          const value = event.getUseValuesFromTriggerTime?.();
+          return typeof value === 'boolean' ? value : true;
+        } catch {
+          return true;
+        }
+      })(),
       assignments,
       triggerInitialValue: initValAttr === null ? undefined : /true|1/i.test(initValAttr),
       triggerPersistent: persistAttr === null ? undefined : /true|1/i.test(persistAttr),
@@ -2683,12 +2749,32 @@ export class SBMLParser {
   }
 
   private extractInitialAssignment(ia: any): SBMLInitialAssignment | null {
+    const symbol = ia.getSymbol();
     const math = ia.getMath();
-    if (!math) return null;
+    if (!math) {
+      this.recordWarning('missingMath',
+        `Initial assignment "${symbol}" has no MathML expression; assignment was omitted.`,
+        'dropped');
+      return null;
+    }
+
+    let formula = this.safeFormulaToString(math);
+    const rawMath = this.rawMathForInitialAssignment(symbol);
+    if (this.mathHasLossyConstructs(rawMath)) {
+      const fromMathMl = this.mathMlToFormula(rawMath!);
+      if (fromMathMl.trim()) formula = fromMathMl;
+    }
+    formula = this.normalizeFormulaIdentifiers(formula);
+    if (!formula.trim()) {
+      this.recordWarning('missingMath',
+        `Initial assignment "${symbol}" has an empty MathML expression; assignment was omitted.`,
+        'dropped');
+      return null;
+    }
 
     return {
-      symbol: ia.getSymbol(),
-      math: this.normalizeFormulaIdentifiers(this.safeFormulaToString(math)),
+      symbol,
+      math: formula,
     };
   }
 }

--- a/src/lib/atomizer/writer/bnglWriter.ts
+++ b/src/lib/atomizer/writer/bnglWriter.ts
@@ -2585,6 +2585,11 @@ export function generateBNGL(
     return Number.isFinite(v) ? v : def;
   };
   const eventMethod = /simulate_ssa|method\s*=>\s*["']?ssa/i.test(options.actions || '') ? 'ssa' : 'ode';
+  const mutableEventIds = new Set<string>([
+    ...(model.rules || []).map(rule => rule.variable).filter((id): id is string => !!id),
+    ...(model.initialAssignments || []).map(assignment => assignment.symbol).filter((id): id is string => !!id),
+    ...(model.events || []).flatMap(event => event.assignments.map(assignment => assignment.variable)),
+  ]);
   const eventCtx: EventTranslationContext = {
     resolveSpeciesPattern: (sbmlId: string) => {
       const b = sbmlToBnglId.get(sbmlId);
@@ -2599,6 +2604,12 @@ export function generateBNGL(
       return undefined;
     },
     isParam: (id: string) => model.parameters.has(id) || model.compartments.has(id),
+    isCompileTimeConstant: (id: string) => {
+      const parameter = model.parameters.get(id);
+      if (parameter) return parameter.constant && !mutableEventIds.has(id);
+      const compartment = model.compartments.get(id);
+      return !!compartment && compartment.constant && !mutableEventIds.has(id);
+    },
     method: eventMethod,
     baseTEnd: parseNum(/t_end\s*=>\s*([0-9.eE+-]+)/, 100),
     baseSteps: parseNum(/n_steps\s*=>\s*([0-9]+)/, 100),

--- a/src/lib/atomizer/writer/eventActions.ts
+++ b/src/lib/atomizer/writer/eventActions.ts
@@ -187,6 +187,8 @@ export interface EventTranslationContext {
   resolveSpeciesPattern: (sbmlId: string) => string | null;
   /** Resolve a parameter/compartment id to its numeric value, else undefined. */
   resolveParam: (id: string) => number | undefined;
+  /** True only for identifiers whose value cannot change during the simulation. */
+  isCompileTimeConstant: (id: string) => boolean;
   /** True if the id names a global parameter or compartment (a valid setParameter target). */
   isParam: (id: string) => boolean;
   /** Simulation method for the synthesized phases. */
@@ -213,7 +215,12 @@ export function synthesizeEventActions(
   const untranslated: Array<{ event: SBMLEvent; reason: string }> = [];
   const scheduled: Array<{ time: number; sets: EventSet[]; priority: number }> = [];
 
-  const fold = (e: string) => foldNumeric(e, ctx.resolveParam);
+  // Only bake identifiers that SBML guarantees are immutable. Folding a mutable parameter to its
+  // initial value changes event assignment-time semantics (for example q := p + 1 after p := 3).
+  const fold = (e: string) => foldNumeric(
+    e,
+    (id) => ctx.isCompileTimeConstant(id) ? ctx.resolveParam(id) : undefined,
+  );
 
   for (const ev of events) {
     const threshold = parseTimeThreshold(ev.trigger);
@@ -263,7 +270,11 @@ export function synthesizeEventActions(
     let priority = 0;
     if (ev.priority) {
       const p = fold(ev.priority);
-      if (p !== null) priority = p;
+      if (p === null) {
+        untranslated.push({ event: ev, reason: `priority "${ev.priority}" is not compile-time constant` });
+        continue;
+      }
+      priority = p;
     }
     scheduled.push({ time, sets, priority });
   }

--- a/tests/atomizer/sbml-core-parity.spec.ts
+++ b/tests/atomizer/sbml-core-parity.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import { Atomizer } from '../../src/lib/atomizer/index';
+import { parseBNGLStrict } from '../../packages/engine/src/parser/BNGLParserWrapper';
+
+const CORE = ['http://www', 'sbml', 'org/sbml/level3/version2/core'].join('.');
+const MATH = ['http://www', 'w3', 'org/1998/Math/MathML'].join('.');
+
+async function atomize(xml: string) {
+  const instance = new Atomizer({ quietMode: true, useId: true, atomize: false });
+  await instance.initialize();
+  const result = await instance.atomize(xml);
+  return { instance, result };
+}
+
+describe('Atomizer SBML Core parity regressions', () => {
+  it('uses SBML identities for empty n-ary MathML operators', async () => {
+    const { result } = await atomize(`
+      <sbml xmlns="${CORE}" level="3" version="2">
+        <model id="emptyOperators">
+          <listOfCompartments><compartment id="c" size="1"/></listOfCompartments>
+          <listOfSpecies><species id="S" compartment="c" initialAmount="1"/></listOfSpecies>
+          <listOfRules>
+            <assignmentRule variable="S"><math xmlns="${MATH}"><apply><plus/></apply></math></assignmentRule>
+          </listOfRules>
+        </model>
+      </sbml>`);
+
+    expect(result.success).toBe(true);
+    expect(() => parseBNGLStrict(result.bngl)).not.toThrow();
+    expect(result.bngl).not.toMatch(/__assign_rule__S\(\)\s*=\s*\(\)/);
+  });
+
+  it('omits missing rule MathML instead of emitting a blank BNGL function', async () => {
+    const { result } = await atomize(`
+      <sbml xmlns="${CORE}" level="3" version="2">
+        <model id="missingRuleMath">
+          <listOfCompartments><compartment id="c" size="1"/></listOfCompartments>
+          <listOfSpecies><species id="S" compartment="c" initialAmount="1"/></listOfSpecies>
+          <listOfRules><assignmentRule variable="S"><math/></assignmentRule></listOfRules>
+        </model>
+      </sbml>`);
+
+    expect(result.success).toBe(true);
+    expect(() => parseBNGLStrict(result.bngl)).not.toThrow();
+    expect(result.bngl).not.toMatch(/S\(\)\s*=\s*$/m);
+    expect(result.bngl).toContain('missingMath');
+  });
+
+  it('preserves explicit useValuesFromTriggerTime=false and refuses unsafe mutable event folding', async () => {
+    const { instance, result } = await atomize(`
+      <sbml xmlns="${CORE}" level="3" version="2">
+        <model id="assignmentTimeEvent">
+          <listOfParameters>
+            <parameter id="x" value="0" constant="false"/>
+            <parameter id="y" value="0" constant="false"/>
+          </listOfParameters>
+          <listOfEvents>
+            <event id="E" useValuesFromTriggerTime="false">
+              <trigger initialValue="true" persistent="true"><math xmlns="${MATH}"><apply><geq/><csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol><cn> 1 </cn></apply></math></trigger>
+              <delay><math xmlns="${MATH}"><cn> 0.1 </cn></math></delay>
+              <listOfEventAssignments>
+                <eventAssignment variable="y"><math xmlns="${MATH}"><apply><plus/><ci> y </ci><ci> x </ci></apply></math></eventAssignment>
+                <eventAssignment variable="x"><math xmlns="${MATH}"><cn type="integer"> 2 </cn></math></eventAssignment>
+              </listOfEventAssignments>
+            </event>
+          </listOfEvents>
+        </model>
+      </sbml>`);
+
+    expect(result.success).toBe(true);
+    expect(instance.getModel()?.events[0]?.useValuesFromTriggerTime).toBe(false);
+    expect(result.bngl).toContain('Events NOT simulated');
+    expect(result.bngl).not.toContain('time-triggered event(s) converted');
+    expect(() => parseBNGLStrict(result.bngl)).not.toThrow();
+  });
+
+  it('applies a model conversionFactor to the generated reaction rule', async () => {
+    const { result } = await atomize(`
+      <sbml xmlns="${CORE}" level="3" version="2">
+        <model id="conversionFactorModel" conversionFactor="cf">
+          <listOfCompartments><compartment id="c" size="1"/></listOfCompartments>
+          <listOfSpecies>
+            <species id="A" compartment="c" initialAmount="1"/>
+            <species id="B" compartment="c" initialAmount="0"/>
+          </listOfSpecies>
+          <listOfParameters>
+            <parameter id="k" value="1"/>
+            <parameter id="cf" value="2"/>
+          </listOfParameters>
+          <listOfReactions>
+            <reaction id="r">
+              <listOfReactants><speciesReference species="A"/></listOfReactants>
+              <listOfProducts><speciesReference species="B"/></listOfProducts>
+              <kineticLaw>
+                <math xmlns="${MATH}"><apply><times/><ci>k</ci><ci>A</ci></apply></math>
+              </kineticLaw>
+            </reaction>
+          </listOfReactions>
+        </model>
+      </sbml>`);
+
+    expect(result.success).toBe(true);
+    expect(() => parseBNGLStrict(result.bngl)).not.toThrow();
+    expect(result.bngl).toMatch(/2\s*\*\s*\(\(/);
+  });
+
+  it('reports the retired requirements package as informational metadata', async () => {
+    const { instance, result } = await atomize(`
+      <sbml xmlns="${CORE}" xmlns:req="http://www.sbml.org/sbml/level3/version1/req/version1" level="3" version="2">
+        <model id="requirementsMetadata">
+          <listOfCompartments><compartment id="c" size="1"/></listOfCompartments>
+        </model>
+      </sbml>`);
+
+    expect(result.success).toBe(true);
+    expect(instance.getModel()?.importWarnings.some(warning => warning.category === 'package:req')).toBe(true);
+  });
+});


### PR DESCRIPTION
Keep the two playground repositories synchronized while retaining Jules-only automation in the fork.

The fork main branch now includes the current RuleWorld changes and the Atomizer work. This PR applies that final shared tree to RuleWorld and removes only:

- `.github/workflows/autoresearch.yml`
- `.github/workflows/ci-failure-fix.yml`

The fork main branch remains unchanged with those workflows and the sole `JULES_API_KEY` secret. After merge, the default branches should match except for those two workflow files.
